### PR TITLE
Enhance store content and styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -21,25 +21,72 @@
   </header>
 
   <main>
-    <h2>Historia</h2>
-    <p>D BRAND fue fundada por cuatro emprendedores con la visión de democratizar el comercio en línea y hacerlo accesible para todos.</p>
+    <section>
+      <h2>Nuestra Historia</h2>
+      <p>
+        D BRAND nació del sueño de cuatro emprendedores que buscaban un espacio donde cualquier
+        persona pudiera ofrecer sus productos sin barreras tecnológicas. Comenzamos como un
+        pequeño proyecto universitario y, gracias al apoyo de la comunidad, hemos crecido hasta
+        convertirnos en una plataforma que conecta a productores locales con compradores de todo el
+        país.
+      </p>
+    </section>
 
-    <h2>Misión</h2>
-    <p>Brindar una plataforma inclusiva, fácil de usar y accesible, con productos de calidad a precios justos.</p>
+    <section>
+      <h2>Misión</h2>
+      <p>
+        Brindar una experiencia de compra transparente y cercana, donde cada producto cuente con
+        información clara sobre su origen y proceso de elaboración. Creemos que la tecnología puede
+        impulsar economías locales y ofrecer mejores oportunidades a quienes deciden emprender.
+      </p>
+    </section>
 
-    <h2>Visión</h2>
-    <p>Convertirnos en la plataforma de comercio electrónico líder en inclusión digital y apoyo a emprendedores globales.</p>
+    <section>
+      <h2>Visión</h2>
+      <p>
+        Convertirnos en la plataforma de comercio electrónico más confiable de Latinoamérica,
+        reconocida por su compromiso con la sostenibilidad y por impulsar historias de éxito en
+        comunidades que tradicionalmente han estado alejadas de la digitalización.
+      </p>
+    </section>
 
-    <h2>Valores</h2>
-    <ul>
-      <li>Innovación</li>
-      <li>Inclusión</li>
-      <li>Calidad</li>
-      <li>Transparencia</li>
-    </ul>
+    <section>
+      <h2>Valores</h2>
+      <ul>
+        <li>Innovación constante para mejorar la experiencia de compra.</li>
+        <li>Inclusión y respeto por la diversidad de personas y productos.</li>
+        <li>Calidad como sello en cada proceso y artículo que ofrecemos.</li>
+        <li>Transparencia en nuestras políticas y en la relación con clientes y proveedores.</li>
+      </ul>
+    </section>
 
-    <h2>Filosofía</h2>
-    <p>Creemos en un mercado justo donde todos puedan competir en igualdad de condiciones, sin importar su tamaño o ubicación.</p>
+    <section>
+      <h2>Nuestro Equipo</h2>
+      <p>
+        Somos diseñadores, programadores y especialistas en atención al cliente que comparten una
+        misma visión: crear un mercado digital humano. Cada integrante aporta su experiencia para
+        desarrollar herramientas accesibles y un servicio amable que responda a las necesidades de
+        nuestros usuarios.
+      </p>
+    </section>
+
+    <section>
+      <h2>Compromiso con la comunidad</h2>
+      <p>
+        Trabajamos con proveedores que adoptan prácticas responsables y fomentamos campañas de
+        consumo consciente. Destinamos parte de nuestras ganancias a programas de capacitación para
+        emprendedores y apoyamos proyectos de impacto social en las regiones donde operamos.
+      </p>
+    </section>
+
+    <section>
+      <h2>Filosofía</h2>
+      <p>
+        Creemos en un mercado justo donde todos puedan competir en igualdad de condiciones, sin
+        importar su tamaño o ubicación. Apostamos por la colaboración, la creatividad y el uso
+        responsable de la tecnología para construir un comercio más humano y sostenible.
+      </p>
+    </section>
   </main>
 
   <footer>

--- a/index.html
+++ b/index.html
@@ -24,14 +24,23 @@
     <section>
       <h2>Bienvenido a D BRAND</h2>
       <p>
-        En <strong>D BRAND</strong> trabajamos para acercarte a productos de calidad, accesibles y con un servicio al cliente excepcional. 
+        En <strong>D BRAND</strong> trabajamos para acercarte a productos de calidad, accesibles y con un servicio al cliente excepcional.
         Nuestra plataforma de comercio electrónico busca ser tu primera opción para comprar desde cualquier lugar y en cualquier momento. 
         Aquí encontrarás artículos de tecnología, moda, hogar, cuidado personal y mucho más.
       </p>
       <p>
-        Navega por nuestras categorías, descubre ofertas y apoya a emprendedores de todo el mundo. 
+        Navega por nuestras categorías, descubre ofertas y apoya a emprendedores de todo el mundo.
         Esta es más que una tienda: es una comunidad que impulsa el comercio justo, transparente e inclusivo.
       </p>
+    </section>
+
+    <section class="features">
+      <h3>¿Por qué comprar con nosotros?</h3>
+      <ul>
+        <li>Envío gratis a partir de $500 MXN</li>
+        <li>Pagos 100% seguros</li>
+        <li>Atención al cliente 24/7</li>
+      </ul>
     </section>
 
     <section class="gallery">
@@ -50,6 +59,21 @@
       <div class="gallery-item">
         <img src="https://placehold.co/200x200?text=Lampara+LED" alt="Producto destacado 3" />
         <p>Lámpara LED ajustable para escritorio con diseño moderno y elegante.</p>
+      </div>
+
+      <div class="gallery-item">
+        <img src="https://placehold.co/200x200?text=Laptop" alt="Producto destacado 4" />
+        <p>Laptop ligera de alto rendimiento perfecta para trabajo y entretenimiento.</p>
+      </div>
+
+      <div class="gallery-item">
+        <img src="https://placehold.co/200x200?text=Cafetera" alt="Producto destacado 5" />
+        <p>Cafetera automática con temporizador y varias intensidades de preparación.</p>
+      </div>
+
+      <div class="gallery-item">
+        <img src="https://placehold.co/200x200?text=Tenis" alt="Producto destacado 6" />
+        <p>Tenis deportivos con tecnología de amortiguación para un mejor desempeño.</p>
       </div>
     </section>
   </main>

--- a/products.html
+++ b/products.html
@@ -22,6 +22,7 @@
   </header>
 
   <main>
+    <p>Explora nuestra amplia selección de artículos y usa el buscador para encontrar lo que necesitas.</p>
     <input type="text" id="search" placeholder="Buscar producto..." />
     <div id="product-list"></div>
   </main>

--- a/script.js
+++ b/script.js
@@ -6,22 +6,50 @@ document.addEventListener('DOMContentLoaded', () => {
     {
       name: 'Camisa básica',
       image: 'https://placehold.co/150x150?text=Camisa',
-      desc: 'Camisa unisex de algodón, disponible en varios colores.'
+      desc: 'Camisa unisex de algodón, disponible en varios colores.',
+      price: '$250'
     },
     {
       name: 'Smartphone',
       image: 'https://placehold.co/150x150?text=Smartphone',
-      desc: 'Teléfono inteligente con cámara de alta resolución y batería duradera.'
+      desc: 'Teléfono inteligente con cámara de alta resolución y batería duradera.',
+      price: '$6,500'
     },
     {
       name: 'Lámpara LED',
       image: 'https://placehold.co/150x150?text=Lampara',
-      desc: 'Ideal para escritorios y espacios de lectura con luz blanca regulable.'
+      desc: 'Ideal para escritorios y espacios de lectura con luz blanca regulable.',
+      price: '$450'
     },
     {
       name: 'Shampoo natural',
       image: 'https://placehold.co/150x150?text=Shampoo',
-      desc: 'Producto orgánico para el cuidado del cabello sin sulfatos ni parabenos.'
+      desc: 'Producto orgánico para el cuidado del cabello sin sulfatos ni parabenos.',
+      price: '$120'
+    },
+    {
+      name: 'Laptop',
+      image: 'https://placehold.co/150x150?text=Laptop',
+      desc: 'Portátil ligera con 16GB de RAM y 512GB SSD.',
+      price: '$18,999'
+    },
+    {
+      name: 'Cafetera automática',
+      image: 'https://placehold.co/150x150?text=Cafetera',
+      desc: 'Cafetera programable con molinillo integrado.',
+      price: '$3,200'
+    },
+    {
+      name: 'Tenis deportivos',
+      image: 'https://placehold.co/150x150?text=Tenis',
+      desc: 'Calzado con amortiguación especial para running.',
+      price: '$1,350'
+    },
+    {
+      name: 'Audífonos Bluetooth',
+      image: 'https://placehold.co/150x150?text=Audifonos',
+      desc: 'Audífonos con cancelación activa de ruido y estuche de carga.',
+      price: '$899'
     }
   ];
 
@@ -33,6 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
       div.innerHTML = `
         <img src="${p.image}" alt="${p.name}" />
         <h4>${p.name}</h4>
+        <p class="price">${p.price}</p>
         <p>${p.desc}</p>
       `;
       productList.appendChild(div);

--- a/style.css
+++ b/style.css
@@ -1,86 +1,189 @@
+/* Paleta neutra y estilos refinados */
+:root {
+  --bg: #f6f5f4;
+  --surface: #ffffff;
+  --primary: #1c1c1c;
+  --accent: #b59d7a;
+  --muted: #e0ddd8;
+}
+
 * {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  font-family: Arial, sans-serif;
+  font-family: 'Helvetica Neue', Arial, sans-serif;
 }
+
 body {
-  background: #f4f4f4;
-  color: #333;
-  padding: 10px;
+  background: var(--bg);
+  color: var(--primary);
+  line-height: 1.6;
 }
-header, footer {
-  background: #222;
-  color: #fff;
-  padding: 15px 0;
+
+header {
+  background: var(--surface);
+  color: var(--primary);
+  padding: 20px 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+footer {
+  background: var(--surface);
+  color: var(--primary);
   text-align: center;
+  padding: 20px 40px;
+  border-top: 1px solid var(--muted);
+  margin-top: 40px;
 }
+
 nav ul {
   display: flex;
-  justify-content: center;
+  gap: 20px;
   list-style: none;
 }
-nav li {
-  margin: 0 15px;
-}
+
 nav a {
-  color: #fff;
+  color: var(--primary);
   text-decoration: none;
+  padding-bottom: 5px;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.3s ease;
 }
+
+nav a:hover {
+  border-color: var(--accent);
+}
+
 main {
-  background: white;
-  padding: 20px;
-  margin-top: 10px;
+  max-width: 1200px;
+  background: var(--surface);
+  padding: 40px;
+  margin: 40px auto;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
 }
-.gallery {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
-  justify-content: center;
+
+.features ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 15px;
+  list-style: none;
   margin-top: 20px;
 }
-.gallery-item {
-  width: 220px;
-  text-align: center;
-  background: #fafafa;
-  border: 1px solid #ddd;
-  padding: 10px;
+
+.features li {
+  background: var(--muted);
+  padding: 15px;
   border-radius: 8px;
+  text-align: center;
 }
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 30px;
+  margin-top: 30px;
+}
+
+.gallery-item {
+  background: var(--surface);
+  border: 1px solid var(--muted);
+  border-radius: 6px;
+  padding: 15px;
+  text-align: center;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.gallery-item:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+}
+
 .gallery-item img {
   max-width: 100%;
   height: auto;
   margin-bottom: 10px;
+  border-radius: 4px;
 }
+
+#search {
+  padding: 10px 14px;
+  width: 100%;
+  max-width: 400px;
+  margin: 10px auto;
+  display: block;
+  border: 1px solid var(--muted);
+  border-radius: 24px;
+  transition: box-shadow 0.3s ease;
+  background: var(--surface);
+}
+
+#search:focus {
+  outline: none;
+  box-shadow: 0 0 5px var(--accent);
+}
+
+#product-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+
+#product-list .gallery-item h4 {
+  margin-bottom: 8px;
+}
+
+#product-list .price {
+  font-weight: bold;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+
 form {
   display: flex;
   flex-direction: column;
   max-width: 400px;
   margin: 0 auto;
 }
-form input, form textarea, form button {
+
+form input,
+form textarea,
+form button {
   margin-bottom: 10px;
   padding: 8px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--muted);
 }
+
 form button {
-  background: #222;
-  color: white;
+  background: var(--primary);
+  color: var(--surface);
   cursor: pointer;
   border: none;
   padding: 10px;
   border-radius: 4px;
+  transition: background 0.3s ease;
 }
+
 form button:hover {
   background: #555;
 }
+
 @media (max-width: 600px) {
-  nav ul {
+  header {
     flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
   }
-  .gallery {
-    flex-direction: column;
-    align-items: center;
+  nav ul {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .features ul {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- adopt a neutral palette and subtle layouts for a refined look across pages
- expand the "Sobre Nosotros" page with detailed history, mission, team and community commitment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c78b666c5483249a3d62792e0fd586