### PR TITLE
Refresh palette with warmer gradients

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,14 @@
 /* Refined minimalist style */
 :root {
-  --primary: #1a1a1a;
-  --secondary: #8c7a67;
-  --light: #f8f8f8;
-  --dark: #222;
+  --primary: #2f2a26;
+  --accent: #8a6a4d;
+  --accent-soft: #cbb99f;
+  --highlight: #5a4c7d;
+  --background: #f3ede3;
+  --background-soft: #e6e1f3;
+  --surface: rgba(255, 253, 248, 0.92);
+  --surface-strong: rgba(255, 255, 255, 0.9);
+  --border-soft: #dacfc4;
 }
 
 * {
@@ -14,26 +19,37 @@
 }
 
 body {
-  background: var(--light);
+  min-height: 100vh;
+  background: radial-gradient(circle at 5% 0%, var(--background-soft), transparent 45%),
+    radial-gradient(circle at 95% 0%, rgba(90, 76, 125, 0.12), transparent 55%),
+    linear-gradient(135deg, #efe6d9 0%, var(--background) 55%, #e7ded3 100%);
   color: var(--primary);
   line-height: 1.6;
-  padding: 0 20px;
+  padding: 0 20px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
 
 header,
 footer {
-  background: #fff;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.75));
   color: var(--primary);
   text-align: center;
-  padding: 20px 0;
+  padding: 24px 0;
+  border-radius: 0 0 18px 18px;
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(138, 106, 77, 0.18);
 }
 
 header {
-  border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid rgba(90, 76, 125, 0.15);
 }
 
 footer {
-  border-top: 1px solid #e5e5e5;
+  margin-top: auto;
+  border-radius: 18px 18px 0 0;
+  border-top: 1px solid rgba(90, 76, 125, 0.12);
 }
 
 nav ul {
@@ -44,11 +60,12 @@ nav ul {
 }
 
 nav a {
-  color: var(--primary);
+  color: var(--highlight);
   text-decoration: none;
   position: relative;
   padding: 8px 0;
-  transition: color 0.3s ease;
+  transition: color 0.3s ease, transform 0.3s ease;
+  font-weight: 600;
 }
 
 nav a::after {
@@ -58,12 +75,13 @@ nav a::after {
   bottom: -2px;
   width: 0;
   height: 2px;
-  background: var(--secondary);
+  background: var(--accent);
   transition: width 0.3s ease;
 }
 
 nav a:hover {
-  color: var(--secondary);
+  color: var(--accent);
+  transform: translateY(-2px);
 }
 
 nav a:hover::after {
@@ -71,12 +89,14 @@ nav a:hover::after {
 }
 
 main {
-  background: #fff;
-  padding: 40px;
-  margin: 30px auto;
+  background: linear-gradient(160deg, var(--surface), var(--surface-strong));
+  padding: 48px 56px;
+  margin: 40px auto;
   max-width: 1100px;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  border-radius: 24px;
+  box-shadow: 0 25px 60px rgba(47, 42, 38, 0.12);
+  border: 1px solid var(--border-soft);
+  backdrop-filter: blur(4px);
 }
 
 .gallery {
@@ -90,23 +110,26 @@ main {
 .gallery-item {
   width: 220px;
   text-align: center;
-  background: #fff;
-  border: 1px solid #e5e5e5;
-  padding: 15px;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  background: linear-gradient(170deg, rgba(255, 255, 255, 0.82), rgba(230, 224, 243, 0.9));
+  border: 1px solid rgba(90, 76, 125, 0.12);
+  padding: 20px 18px;
+  border-radius: 18px;
+  box-shadow: 0 18px 35px rgba(47, 42, 38, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .gallery-item:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-6px);
+  box-shadow: 0 25px 45px rgba(47, 42, 38, 0.15);
+  border-color: rgba(138, 106, 77, 0.35);
 }
 
 .gallery-item img {
   max-width: 100%;
   height: auto;
   margin-bottom: 10px;
+  border-radius: 12px;
+  box-shadow: 0 12px 25px rgba(47, 42, 38, 0.12);
 }
 
 .features ul {
@@ -119,11 +142,12 @@ main {
 }
 
 .features li {
-  background: none;
+  background: linear-gradient(135deg, rgba(203, 185, 159, 0.25), rgba(138, 106, 77, 0.1));
   color: var(--primary);
-  padding: 10px 20px;
-  border: 1px solid #e5e5e5;
-  border-radius: 30px;
+  padding: 12px 28px;
+  border: 1px solid rgba(203, 185, 159, 0.5);
+  border-radius: 40px;
+  backdrop-filter: blur(2px);
 }
 
 #search {
@@ -132,14 +156,16 @@ main {
   max-width: 400px;
   margin: 20px auto;
   display: block;
-  border: 1px solid #ddd;
+  border: 1px solid rgba(90, 76, 125, 0.2);
   border-radius: 30px;
-  transition: box-shadow 0.3s ease;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease;
+  background: rgba(255, 255, 255, 0.85);
 }
 
 #search:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(140, 122, 103, 0.3);
+  border-color: rgba(90, 76, 125, 0.45);
+  box-shadow: 0 0 0 4px rgba(90, 76, 125, 0.18);
 }
 
 #product-list {
@@ -154,8 +180,8 @@ main {
 }
 
 #product-list .price {
-  font-weight: bold;
-  color: var(--secondary);
+  font-weight: 700;
+  color: var(--accent);
   margin-bottom: 8px;
 }
 
@@ -171,22 +197,32 @@ form textarea,
 form button {
   margin-bottom: 10px;
   padding: 8px;
-  border-radius: 4px;
-  border: 1px solid #ccc;
+  border-radius: 8px;
+  border: 1px solid rgba(90, 76, 125, 0.2);
+  background: rgba(255, 255, 255, 0.88);
 }
 
 form button {
-  background: var(--secondary);
+  background: linear-gradient(120deg, var(--highlight), var(--accent));
   color: white;
   cursor: pointer;
   border: none;
-  padding: 10px;
-  border-radius: 4px;
-  transition: background 0.3s ease;
+  padding: 12px;
+  border-radius: 28px;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 form button:hover {
-  background: #6f5a46;
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(90, 76, 125, 0.25);
+}
+
+a {
+  color: var(--highlight);
+}
+
+a:hover {
+  color: var(--accent);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- replace the monochrome theme with a warm, elegant color palette and richer gradients
- add refined card, navigation, and button treatments to complement the new tones
- tweak layout containers with softer borders, shadows, and spacing for a polished look

## Testing
- not run (static files)


------
https://chatgpt.com/codex/tasks/task_e_68c84c29f3a0832499d475e0f005f7f6